### PR TITLE
Create 368-token-economics

### DIFF
--- a/ideas/368-token-economics
+++ b/ideas/368-token-economics
@@ -1,0 +1,67 @@
+---
+id: #368-token-economics
+title: Token Economics
+status: research
+lead-contributor: jarrad
+contributors:
+    - carl
+    - barry
+    - corey
+budget:
+- actual: xxx
+- estimate: yyy
+- currency: ETH/USD/SNT
+---
+
+# Swarm proposal
+
+## Summary and Goal(s)
+
+To model the Status Network token economy based on current SNT use-cases.
+The goal is to model the SNT value potential for investment, as well as inform design decisions.
+
+## Communication
+(required)
+`status channel (same as swarm id)`: [#368-token-economics](https://get.status.im/chat/public/368-token-economics)
+`sync frequency`: Weekly Sync
+
+## Research
+Completion by end of March, 2019
+
+Barry has already made several models here:
+https://beta.observablehq.com/@bgits
+
+And we have started collecting some empirical growth data.
+
+## Specification
+
+> do after `Research`
+
+(required)
+`timebox specification (approx)`
+
+(optional)
+`user stories`, `architecture`, `designs`, `PoC`
+
+## Implementation
+
+(required)
+`timebox implementation (approx)`
+
+> do after `Specification`
+
+> All swarm contributors should test and break the implementation, especially developers
+
+(required)
+`document progress`
+
+(optional)
+`townhall demo`
+
+## Maintenance
+
+`lead-contributor`,`post-mortems`
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
To model the Status Network token economy based on current SNT use-cases.
The goal is to model the SNT value potential for investment, as well as inform design decisions.